### PR TITLE
Accepting dots in query paths

### DIFF
--- a/src/NuGet.Licenses/Web.config
+++ b/src/NuGet.Licenses/Web.config
@@ -1,8 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-  For more information on how to configure your ASP.NET application, please visit
-  https://go.microsoft.com/fwlink/?LinkId=301880
-  -->
 <configuration>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0"/>
@@ -11,19 +7,171 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
     <add key="Licenses.InstrumentationKey" value=""/>
   </appSettings>
+ <!-- Configure paths containing static files -->
+  <location path="Content">
+    <system.web>
+      <httpHandlers>
+        <clear/>
+      </httpHandlers>
+    </system.web>
+    <system.webServer>
+      <handlers>
+        <clear/>
+        <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read"/>
+      </handlers>
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By"/>
+        </customHeaders>
+      </httpProtocol>
+    </system.webServer>
+  </location>
+  <location path="Scripts">
+    <system.web>
+      <httpHandlers>
+        <clear/>
+      </httpHandlers>
+    </system.web>
+    <system.webServer>
+      <handlers>
+        <clear/>
+        <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read"/>
+      </handlers>
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By"/>
+        </customHeaders>
+      </httpProtocol>
+    </system.webServer>
+  </location>
+  <location path="Public">
+    <system.web>
+      <httpHandlers>
+        <clear/>
+      </httpHandlers>
+    </system.web>
+    <system.webServer>
+      <handlers>
+        <clear/>
+        <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read"/>
+      </handlers>
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By"/>
+        </customHeaders>
+      </httpProtocol>
+    </system.webServer>
+  </location>
   <system.web>
+    <httpCookies requireSSL="true" httpOnlyCookies="true"/>
     <compilation debug="true" targetFramework="4.6.2"/>
-    <httpRuntime targetFramework="4.6.2"/>
+    <pages controlRenderingCompatibilityVersion="4.0">
+      <namespaces>
+        <add namespace="System.Web.Helpers"/>
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
+        <add namespace="System.Web.WebPages"/>
+      </namespaces>
+    </pages>
+    <httpRuntime targetFramework="4.6.2" maxQueryStringLength="1000" maxRequestLength="256000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" relaxedUrlToFileSystemMapping="true" enableVersionHeader="false"/>
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
     </httpModules>
+    <httpHandlers>
+      <!-- Remove Default HTTP Handler -->
+      <remove path="*" verb="GET,HEAD,POST"/>
+    </httpHandlers>
+    <customErrors mode="RemoteOnly" defaultRedirect="~/Errors" redirectMode="ResponseRewrite">
+    </customErrors>
+    <sessionState mode="Off"/>
   </system.web>
+  <system.webServer>
+    <tracing>
+      <traceFailedRequests>
+        <clear/>
+        <add path="*">
+          <traceAreas>
+            <add provider="ASPNET" areas="Infrastructure,Module,Page,AppServices" verbosity="Warning"/>
+          </traceAreas>
+          <failureDefinitions statusCodes="500-599"/>
+        </add>
+      </traceFailedRequests>
+    </tracing>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By"/>
+        <add name="Content-Security-Policy" value="frame-ancestors 'none'"/>
+        <add name="X-Frame-Options" value="deny"/>
+        <add name="X-XSS-Protection" value="1; mode=block"/>
+        <add name="X-Content-Type-Options" value="nosniff"/>
+        <add name="Strict-Transport-Security" value="max-age=31536000"/>
+      </customHeaders>
+    </httpProtocol>
+    <handlers>
+      <!-- This is an essential part of the security configuration, since we disable request filtering in order
+            to support Package IDs with ".vb", ".config", etc. We MUST remove the ability to serve static files from the main
+            site. Only the ~/Public folder supports static file serving. DO NOT remove this setting without a security review -->
+      <remove name="StaticFile"/>
+    </handlers>
+    <modules runAllManagedModulesForAllRequests="true">
+      <remove name="RoleManager"/>
+      <remove name="ApplicationInsightsWebTracking"/>
+      <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler"/>
+    </modules>
+    <validation validateIntegratedModeConfiguration="false"/>
+    <httpErrors errorMode="DetailedLocalOnly">
+    </httpErrors>
+    <security>
+      <requestFiltering>
+        <!-- Clearing hidden segments and file extensions is done to allow Package IDs with ".vb", ".config", etc.
+                in their name to be served. As a result, we disable static file serving above. DO NOT change these settings
+                without a security review -->
+        <fileExtensions>
+          <clear/>
+        </fileExtensions>
+        <hiddenSegments>
+          <clear/>
+        </hiddenSegments>
+        <requestLimits maxQueryString="1000" maxAllowedContentLength="10000"/>
+      </requestFiltering>
+    </security>
+    <httpCompression directory="%SystemDrive%\inetpub\temp\IIS Temporary Compressed Files">
+      <scheme name="gzip" dll="%Windir%\system32\inetsrv\gzip.dll"/>
+      <dynamicTypes>
+        <add mimeType="text/*" enabled="true"/>
+        <add mimeType="message/*" enabled="true"/>
+        <add mimeType="application/javascript" enabled="true"/>
+        <add mimeType="application/x-javascript" enabled="true"/>
+        <add mimeType="application/json" enabled="true"/>
+        <add mimeType="application/atom+xml" enabled="true"/>
+        <add mimeType="application/atom+xml;charset=utf-8" enabled="true"/>
+        <add mimeType="application/atom+xml; type=feed" enabled="true"/>
+        <add mimeType="application/atom+xml; type=feed; charset=utf-8" enabled="true"/>
+        <add mimeType="*/*" enabled="false"/>
+      </dynamicTypes>
+      <staticTypes>
+        <add mimeType="text/*" enabled="true"/>
+        <add mimeType="message/*" enabled="true"/>
+        <add mimeType="application/javascript" enabled="true"/>
+        <add mimeType="application/x-javascript" enabled="true"/>
+        <add mimeType="application/json" enabled="true"/>
+        <add mimeType="application/atom+xml" enabled="true"/>
+        <add mimeType="application/atom+xml;charset=utf-8" enabled="true"/>
+        <add mimeType="application/atom+xml; type=feed" enabled="true"/>
+        <add mimeType="application/atom+xml; type=feed; charset=utf-8" enabled="true"/>
+        <add mimeType="*/*" enabled="false"/>
+      </staticTypes>
+    </httpCompression>
+    <urlCompression doStaticCompression="true" doDynamicCompression="true"/>
+  </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.1" newVersion="4.0.2.1"/>
-      </dependentAssembly>      
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
         <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
@@ -46,26 +194,38 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-  <system.webServer>
-    <modules>
-      <remove name="TelemetryCorrelationHttpModule"/>
-      <add name="TelemetryCorrelationHttpModule"
-        type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation"
-        preCondition="integratedMode,managedHandler"/>
-      <remove name="ApplicationInsightsHttpModule"/>
-      <add name="ApplicationInsightsHttpModule"
-           type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"
-           preCondition="managedHandler" />
-    </modules>
-    <handlers>
-      <!--
-      <remove name="UrlRoutingHandler"/>
-      <add name="UrlRoutingHandler"
-         type="System.Web.Routing.UrlRoutingHandler, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
-         path="/*"
-         verb="GET"/>
-       -->
-    </handlers>
-    <validation validateIntegratedModeConfiguration="false" />
-  </system.webServer>
+  <system.serviceModel>
+    <serviceHostingEnvironment aspNetCompatibilityEnabled="true" multipleSiteBindingsEnabled="true"/>
+    <extensions>
+      <!-- Azure Service Bus extensions, added automatically by the WindowsAzure.ServiceBus package. -->
+      <behaviorExtensions>
+        <add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+      </behaviorExtensions>
+      <bindingElementExtensions>
+        <add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+      </bindingElementExtensions>
+      <bindingExtensions>
+        <add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+        <add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
+      </bindingExtensions>
+    </extensions>
+  </system.serviceModel>
+  <system.diagnostics>
+    <trace autoflush="true" indentsize="0">
+      <listeners>
+        <add name="myAppInsightsListener" type="Microsoft.ApplicationInsights.TraceListener.ApplicationInsightsTraceListener, Microsoft.ApplicationInsights.TraceListener"/>
+      </listeners>
+    </trace>
+  </system.diagnostics>
 </configuration>

--- a/src/NuGet.Licenses/Web.config
+++ b/src/NuGet.Licenses/Web.config
@@ -57,6 +57,15 @@
            type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"
            preCondition="managedHandler" />
     </modules>
+    <handlers>
+      <!--
+      <remove name="UrlRoutingHandler"/>
+      <add name="UrlRoutingHandler"
+         type="System.Web.Routing.UrlRoutingHandler, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
+         path="/*"
+         verb="GET"/>
+       -->
+    </handlers>
     <validation validateIntegratedModeConfiguration="false" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
By default ASP.NET MVC app handles dots in query paths in some special way that so that if query path contains dot it does not reach the controller. There also seem to be some security issues with common ways of allowing those to reach the controllers. Since the issue was solved in Gallery (and hopefully security reviewed), I just took Gallery's web.config and dropped all (most?) the irrelevant parts.

We need to be able to process paths with dots since some of the license IDs have dots in them ([Apache-2.0](https://spdx.org/licenses/Apache-2.0.html))