### PR TITLE
Unavailable parsed result of composite license expression should not be shown. 

### DIFF
--- a/src/NuGet.Licenses/Controllers/LicenseController.cs
+++ b/src/NuGet.Licenses/Controllers/LicenseController.cs
@@ -182,7 +182,7 @@ namespace NuGet.Licenses.Controllers
                 if (!isValidSegment)
                 {
                     stopwatch.Stop();
-                    _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed.TotalSeconds);
+                    _logger.LogInformation("Validating composite licenseExpression uses: {ElapsedTime} s", stopwatch.Elapsed.TotalSeconds);
                     return UnknownLicense(segment.Value);
                 }
 
@@ -193,7 +193,7 @@ namespace NuGet.Licenses.Controllers
                     if (!_licenseFileService.DoesLicenseFileExist(segment.Value))
                     {
                         stopwatch.Stop();
-                        _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed.TotalSeconds);
+                        _logger.LogInformation("Validating composite licenseExpression uses: {ElapsedTime} s", stopwatch.Elapsed.TotalSeconds);
                         return UnknownLicense(segment.Value);
                     }
                 }
@@ -206,7 +206,7 @@ namespace NuGet.Licenses.Controllers
             }
 
             stopwatch.Stop();
-            _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed.TotalSeconds);
+            _logger.LogInformation("Validating composite licenseExpression uses: {ElapsedTime} s", stopwatch.Elapsed.TotalSeconds);
             return View("CompositeLicenseExpression", new CompositeLicenseExpressionViewModel(allSegments));
         }
 

--- a/src/NuGet.Licenses/Controllers/LicenseController.cs
+++ b/src/NuGet.Licenses/Controllers/LicenseController.cs
@@ -154,7 +154,7 @@ namespace NuGet.Licenses.Controllers
             var allSegments = _licenseExpressionSegmentator.SplitFullExpression(licenseExpression, meaningfulSegments);
 
             var stopwatch = Stopwatch.StartNew();
-            foreach (var segment in allSegments.Where(s => IsLicenseOrException(s)))
+            foreach (var segment in allSegments.Where(IsLicenseOrException))
             {
                 var isValidSegment = false;
                 if (NuGetLicenseData.ExceptionList.TryGetValue(segment.Value, out var exceptionData))
@@ -182,16 +182,18 @@ namespace NuGet.Licenses.Controllers
                 if (!isValidSegment)
                 {
                     stopwatch.Stop();
-                    _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed);
+                    _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed.TotalSeconds);
                     return UnknownLicense(segment.Value);
                 }
 
                 try
                 {
+                    // The Licenses folder in App_Data does not contain all the SPDX licenses' content.
+                    // If the customer tries to fetch the content of a SPDX expression which we don't support, it will return UnknownLicense here.
                     if (!_licenseFileService.DoesLicenseFileExist(segment.Value))
                     {
                         stopwatch.Stop();
-                        _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed);
+                        _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed.TotalSeconds);
                         return UnknownLicense(segment.Value);
                     }
                 }
@@ -204,7 +206,7 @@ namespace NuGet.Licenses.Controllers
             }
 
             stopwatch.Stop();
-            _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed);
+            _logger.LogInformation("Validating composite licenseExpression uses: {elapsedTime} s", stopwatch.Elapsed.TotalSeconds);
             return View("CompositeLicenseExpression", new CompositeLicenseExpressionViewModel(allSegments));
         }
 

--- a/src/NuGet.Licenses/Controllers/LicenseController.cs
+++ b/src/NuGet.Licenses/Controllers/LicenseController.cs
@@ -151,6 +151,25 @@ namespace NuGet.Licenses.Controllers
             var meaningfulSegments = _licenseExpressionSegmentator.GetLicenseExpressionSegments(licenseExpressionRoot);
             var allSegments = _licenseExpressionSegmentator.SplitFullExpression(licenseExpression, meaningfulSegments);
 
+            foreach(var segment in allSegments)
+            {
+                if (segment.Type == CompositeLicenseExpressionSegmentType.LicenseIdentifier || segment.Type == CompositeLicenseExpressionSegmentType.ExceptionIdentifier)
+                {
+                    try
+                    {
+                        if (!_licenseFileService.DoesLicenseFileExist(segment.Value))
+                        {
+                            return UnknownLicense(segment.Value);
+                        }
+                    }
+                    catch (ArgumentException e)
+                    {
+                        _logger.LogError(0, e, "Got exception while attempting to get license contents due to the invalid license: {licenseIdentifier}", segment.Value);
+                        return InvalidRequest();
+                    }
+                }
+            }
+
             return View("CompositeLicenseExpression", new CompositeLicenseExpressionViewModel(allSegments));
         }
     }

--- a/test/NuGet.Licenses.Tests/LicenseControllerFacts.cs
+++ b/test/NuGet.Licenses.Tests/LicenseControllerFacts.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Web;
-using System.Web.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Licenses.Controllers;
 using NuGet.Licenses.Models;
 using NuGet.Licenses.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
 using Xunit;
 
 namespace NuGet.Licenses.Tests
@@ -55,27 +57,210 @@ namespace NuGet.Licenses.Tests
             Assert.Equal("InvalidRequest", viewResult.ViewName);
         }
 
+        [Theory]
+        [MemberData(nameof(GetValidCompositeLicenseExpression))]
+        public void HandlesValidCompositeLicenseExpression(string licenseExpression,
+                                                           List<CompositeLicenseExpressionSegment> allSegments)
+        {
+            // Arrange
+            var segmentatorService = new Mock<ILicenseExpressionSegmentator>();
+            segmentatorService
+                .Setup(x => x.SplitFullExpression(licenseExpression, It.IsAny<List<CompositeLicenseExpressionSegment>>()))
+                .Returns(allSegments);
+            var licenseFileService = new Mock<ILicenseFileService>();
+            licenseFileService
+                .Setup(x => x.DoesLicenseFileExist(It.IsAny<string>()))
+                .Returns(true);
+
+            var controller = CreateController(segmentator: segmentatorService, licenseFileService: licenseFileService);
+
+            // Act
+            var result = controller.DisplayLicense(licenseExpression);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsType<CompositeLicenseExpressionViewModel>(viewResult.Model);
+            var segments = model.Segments;
+            Assert.Equal(allSegments.Count, segments.Count);
+            for (var i = 0; i < segments.Count; i++)
+            {
+                Assert.Equal(allSegments.ElementAt(i).Type, segments.ElementAt(i).Type);
+                Assert.Equal(allSegments.ElementAt(i).Value, segments.ElementAt(i).Value);
+            }
+        }
+
+        public static IEnumerable<object[]> GetValidCompositeLicenseExpression
+        {
+            get
+            {
+                yield return new object[] {
+                    "MIT AND AAL",
+                    new List<CompositeLicenseExpressionSegment>
+                    {
+                        new CompositeLicenseExpressionSegment("MIT", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AND", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AAL", CompositeLicenseExpressionSegmentType.LicenseIdentifier)
+                    }
+                };
+                yield return new object[] {
+                    "MIT WITH Bison-exception-2.2",
+                    new List<CompositeLicenseExpressionSegment>
+                    {
+                        new CompositeLicenseExpressionSegment("MIT", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("WITH", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("Bison-exception-2.2", CompositeLicenseExpressionSegmentType.ExceptionIdentifier)
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInValidCompositeLicenseExpression))]
+        public void HandlesInValidCompositeLicenseExpression(string licenseExpression,
+                                                             string invalidLicenseName,
+                                                             List<CompositeLicenseExpressionSegment> allSegments)
+        {
+            // Arrange
+            var segmentatorService = new Mock<ILicenseExpressionSegmentator>();
+            segmentatorService
+                .Setup(x => x.SplitFullExpression(licenseExpression, It.IsAny<List<CompositeLicenseExpressionSegment>>()))
+                .Returns(allSegments);
+            var licenseFileService = new Mock<ILicenseFileService>();
+            licenseFileService
+                .Setup(x => x.DoesLicenseFileExist(It.IsAny<string>()))
+                .Returns(true);
+
+            var controller = CreateController(segmentator: segmentatorService, licenseFileService: licenseFileService);
+
+            // Act
+            var result = controller.DisplayLicense(licenseExpression);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsType<UnknownLicenseModel>(viewResult.Model);
+            Assert.Equal(invalidLicenseName, model.LicenseName);
+            Assert.Equal("UnknownLicense", viewResult.ViewName);
+        }
+
+        public static IEnumerable<object[]> GetInValidCompositeLicenseExpression
+        {
+            get
+            {
+                yield return new object[] {
+                    "MIT AND UnknownLicense",
+                    "UnknownLicense",
+                    new List<CompositeLicenseExpressionSegment>
+                    {
+                        new CompositeLicenseExpressionSegment("MIT", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AND", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("UnknownLicense", CompositeLicenseExpressionSegmentType.LicenseIdentifier)
+                    }
+                };
+                yield return new object[] {
+                    "UnknownLicense AND MIT",
+                    "UnknownLicense",
+                    new List<CompositeLicenseExpressionSegment>
+                    {
+                        new CompositeLicenseExpressionSegment("UnknownLicense", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AND", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("MIT", CompositeLicenseExpressionSegmentType.LicenseIdentifier)
+                    }
+                };
+                yield return new object[] {
+                    "MIT AND UnknownLicense AND UnknownLicense2",
+                    "UnknownLicense",
+                    new List<CompositeLicenseExpressionSegment>
+                    {
+                        new CompositeLicenseExpressionSegment("MIT", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AND", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("UnknownLicense", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AND", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("UnknownLicense2", CompositeLicenseExpressionSegmentType.LicenseIdentifier)
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetValidCompositeLicenseExpressionButNoLicenseFile))]
+        public void HandlesValidCompositeLicenseExpressionButNoLicenseFile(string licenseExpression,
+                                                                           string invalidLicenseName,
+                                                                           List<CompositeLicenseExpressionSegment> allSegments)
+        {
+            // Arrange
+            var segmentatorService = new Mock<ILicenseExpressionSegmentator>();
+            segmentatorService
+                .Setup(x => x.SplitFullExpression(licenseExpression, It.IsAny<List<CompositeLicenseExpressionSegment>>()))
+                .Returns(allSegments);
+            var licenseFileService = new Mock<ILicenseFileService>();
+            licenseFileService
+                .Setup(x => x.DoesLicenseFileExist(invalidLicenseName))
+                .Returns(false);
+
+            var controller = CreateController(segmentator: segmentatorService, licenseFileService: licenseFileService);
+
+            // Act
+            var result = controller.DisplayLicense(licenseExpression);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsType<UnknownLicenseModel>(viewResult.Model);
+            Assert.Equal(invalidLicenseName, model.LicenseName);
+            Assert.Equal("UnknownLicense", viewResult.ViewName);
+        }
+
+        public static IEnumerable<object[]> GetValidCompositeLicenseExpressionButNoLicenseFile
+        {
+            get
+            {
+                yield return new object[] {
+                    "MIT AND AAL",
+                    "MIT",
+                    new List<CompositeLicenseExpressionSegment>
+                    {
+                        new CompositeLicenseExpressionSegment("MIT", CompositeLicenseExpressionSegmentType.LicenseIdentifier),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AND", CompositeLicenseExpressionSegmentType.Operator),
+                        new CompositeLicenseExpressionSegment(" ", CompositeLicenseExpressionSegmentType.Other),
+                        new CompositeLicenseExpressionSegment("AAL", CompositeLicenseExpressionSegmentType.LicenseIdentifier)
+                    }
+                };
+            }
+        }
+
         private LicenseController CreateController(
-            ILicenseExpressionSegmentator segmentator = null,
-            ILogger<LicenseController> logger = null,
-            ILicenseFileService licenseFileService = null)
+            Mock<ILicenseExpressionSegmentator> segmentator = null,
+            Mock<ILogger<LicenseController>> logger = null,
+            Mock<ILicenseFileService> licenseFileService = null)
         {
             if (segmentator == null)
             {
-                segmentator = Mock.Of<ILicenseExpressionSegmentator>();
+                segmentator = new Mock<ILicenseExpressionSegmentator>();
             }
 
             if (logger == null)
             {
-                logger = Mock.Of<ILogger<LicenseController>>();
+                logger = new Mock<ILogger<LicenseController>>();
             }
 
             if (licenseFileService == null)
             {
-                licenseFileService = Mock.Of<ILicenseFileService>();
+                licenseFileService = new Mock<ILicenseFileService>();
             }
 
-            var controller = new LicenseController(segmentator, logger, licenseFileService);
+            var controller = new LicenseController(segmentator.Object, logger.Object, licenseFileService.Object);
             var httpContextMock = new Mock<HttpContextBase>();
             httpContextMock
                 .SetupGet(ctx => ctx.Response)


### PR DESCRIPTION
For composite license expression, we should not show the unavailable parsed result. 
Fix: https://github.com/NuGet/Engineering/issues/1893
Test cases will committed later. 