### PR TITLE
Proper error display in Azure

### DIFF
--- a/src/NuGet.Licenses/App_Start/RouteConfig.cs
+++ b/src/NuGet.Licenses/App_Start/RouteConfig.cs
@@ -21,11 +21,6 @@ namespace NuGet.Licenses
                 defaults: new { controller = "Error", action = "Index" });
 
             routes.MapRoute(
-                name: "ErrorSpecific",
-                url: "Error/{status}",
-                defaults: new { controller = "Error", action = "Specific" });
-
-            routes.MapRoute(
                 name: "LicenseExpression",
                 url: "{licenseExpression}",
                 defaults: new { controller = "License", action = "DisplayLicense" });

--- a/src/NuGet.Licenses/Controllers/ErrorController.cs
+++ b/src/NuGet.Licenses/Controllers/ErrorController.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Mvc;
+
+namespace NuGet.Licenses.Controllers
+{
+    public class ErrorController : Controller
+    {
+        public ActionResult Index()
+        {
+            return View("Error");
+        }
+    }
+}

--- a/src/NuGet.Licenses/Controllers/LicenseController.cs
+++ b/src/NuGet.Licenses/Controllers/LicenseController.cs
@@ -34,7 +34,6 @@ namespace NuGet.Licenses.Controllers
 
         public ActionResult DisplayLicense(string licenseExpression)
         {
-            var issueId = Guid.NewGuid();
             ViewBag.IssueId = Activity.Current?.Id;
 
             if (NuGetLicenseData.ExceptionList.TryGetValue(licenseExpression, out var exceptionData))
@@ -103,6 +102,7 @@ namespace NuGet.Licenses.Controllers
         {
             var model = new InvalidRequestModel(errorText);
             Response.StatusCode = 400;
+            Response.TrySkipIisCustomErrors = true;
             return View("InvalidRequest", model);
         }
 
@@ -114,6 +114,7 @@ namespace NuGet.Licenses.Controllers
         private ActionResult UnknownLicense(string licenseIdentifier)
         {
             Response.StatusCode = 404;
+            Response.TrySkipIisCustomErrors = true;
             return View("UnknownLicense", new UnknownLicenseModel(licenseIdentifier));
         }
 

--- a/src/NuGet.Licenses/NuGet.Licenses.csproj
+++ b/src/NuGet.Licenses/NuGet.Licenses.csproj
@@ -69,6 +69,7 @@
     <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Controllers\ErrorController.cs" />
     <Compile Include="Controllers\LicenseController.cs" />
     <Compile Include="ErrorHandler\AiHandleErrorAttribute.cs" />
     <Compile Include="Global.asax.cs">
@@ -296,7 +297,6 @@
     </Content>
     <Content Include="Views\Web.config" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <PackageReference Include="Autofac.Mvc5">
       <Version>4.0.2</Version>

--- a/src/NuGet.Licenses/Web.config
+++ b/src/NuGet.Licenses/Web.config
@@ -83,7 +83,7 @@
       <!-- Remove Default HTTP Handler -->
       <remove path="*" verb="GET,HEAD,POST"/>
     </httpHandlers>
-    <customErrors mode="RemoteOnly" defaultRedirect="~/Errors" redirectMode="ResponseRewrite">
+    <customErrors mode="RemoteOnly" defaultRedirect="~/Error" redirectMode="ResponseRewrite">
     </customErrors>
     <sessionState mode="Off"/>
   </system.web>
@@ -123,7 +123,7 @@
       <add name="ApplicationInsightsHttpModule" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler"/>
     </modules>
     <validation validateIntegratedModeConfiguration="false"/>
-    <httpErrors errorMode="DetailedLocalOnly">
+    <httpErrors errorMode="DetailedLocalOnly" existingResponse="Auto">
     </httpErrors>
     <security>
       <requestFiltering allowDoubleEscaping="true">


### PR DESCRIPTION
Currently, while deployed to Azure URLs error messages emitted from the controller are not propagated all the way to the user browser. So for URLs like http://nuget-dev-ussc-licenses.azurewebsites.net/MIT1 we see generic IIS error message.

This change does the following:
* Introduces the `ErrorController` as a catch-all source for error pages;
* Fixes the route configuration for errors to a correct one;
* sets the `httpError` `existingResponse` setting to `Auto` that enables to use `Response.TrySkipIisCustomErrors = true` in the code to instruct IIS not to use custom error handler and return the response body as is.
* License controller is updated to use above setting.