### PR TITLE
Actions should restrict to intended HTTP methods

### DIFF
--- a/src/NuGet.Licenses/Controllers/ErrorController.cs
+++ b/src/NuGet.Licenses/Controllers/ErrorController.cs
@@ -7,6 +7,7 @@ namespace NuGet.Licenses.Controllers
 {
     public class ErrorController : Controller
     {
+        [AcceptVerbs(HttpVerbs.Get | HttpVerbs.Head)]
         public ActionResult Index()
         {
             return View("Error");

--- a/src/NuGet.Licenses/Controllers/LicenseController.cs
+++ b/src/NuGet.Licenses/Controllers/LicenseController.cs
@@ -28,11 +28,13 @@ namespace NuGet.Licenses.Controllers
             _licenseFileService = licenseFileService ?? throw new ArgumentNullException(nameof(licenseFileService));
         }
 
+        [AcceptVerbs(HttpVerbs.Get | HttpVerbs.Head)]
         public ActionResult Index()
         {
             return Redirect("https://aka.ms/licenses.nuget.org");
         }
 
+        [AcceptVerbs(HttpVerbs.Get | HttpVerbs.Head)]
         public ActionResult DisplayLicense(string licenseExpression)
         {
             ViewBag.IssueId = Activity.Current?.Id;


### PR DESCRIPTION
These methods are only intended to be hit over `GET` or `HEAD`, but right now they have no restriction.