### PR TITLE
Enable code signing and fix SDL errors

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,7 +10,7 @@ param (
     [string]$PackageSuffix,
     [string]$Branch,
     [string]$CommitSHA,
-    [string]$BuildBranch = '1f8e102c9f36a3f06b23fb22cae76d655b033362'
+    [string]$BuildBranch = '8209830d5f760e344de359a3bcf684bf36e0a8d5'
 )
 
 Set-StrictMode -Version 1.0

--- a/src/NuGet.Licenses/GlobalSuppressions.cs
+++ b/src/NuGet.Licenses/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+[module: SuppressMessage("Microsoft.Security.Web.Configuration", "CA3103:EnableFormsRequireSSL", Justification = "Forms authentication is not enabled.")]
+[module: SuppressMessage("Microsoft.Security.Web.Configuration", "CA3119:EnableHttpCookiesRequireSsl", Justification = "Enabled in root web.config, which is inherited by other configurations.")]

--- a/src/NuGet.Licenses/NuGet.Licenses.csproj
+++ b/src/NuGet.Licenses/NuGet.Licenses.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Models\CompositeLicenseExpressionSegment.cs" />
     <Compile Include="Models\CompositeLicenseExpressionSegmentType.cs" />
     <Compile Include="Models\CompositeLicenseExpressionViewModel.cs" />
@@ -301,6 +302,11 @@
     <PackageReference Include="Autofac.Mvc5">
       <Version>4.0.2</Version>
     </PackageReference>
+    <PackageReference Include="MicroBuild.Core">
+      <Version>0.3.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights">
       <Version>2.8.1</Version>
     </PackageReference>
@@ -388,6 +394,14 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <SignPath>..\..\build</SignPath>
+    <SignPath Condition="'$(BUILD_SOURCESDIRECTORY)' != ''">$(BUILD_SOURCESDIRECTORY)\build</SignPath>
+    <SignPath Condition="'$(NuGetBuildPath)' != ''">$(NuGetBuildPath)</SignPath>
+    <SignType Condition="'$(SignType)' == ''">none</SignType>
+  </PropertyGroup>
+  <Import Project="$(SignPath)\sign.targets" Condition="Exists('$(SignPath)\sign.targets')" />
+  <Import Project="$(SignPath)\sign.microbuild.targets" Condition="Exists('$(SignPath)\sign.microbuild.targets')" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">

--- a/src/NuGet.Licenses/Views/Web.config
+++ b/src/NuGet.Licenses/Views/Web.config
@@ -34,7 +34,9 @@
   </system.webServer>
 
   <system.web>
-    <compilation>
+    <httpCookies requireSSL="true" httpOnlyCookies="true"/>
+    <httpRuntime enableVersionHeader="false"/>
+    <compilation debug="false">
       <assemblies>
         <add assembly="System.Web.Mvc, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
       </assemblies>

--- a/src/NuGet.Licenses/Web.config
+++ b/src/NuGet.Licenses/Web.config
@@ -64,7 +64,7 @@
   </location>
   <system.web>
     <httpCookies requireSSL="true" httpOnlyCookies="true"/>
-    <compilation debug="true" targetFramework="4.6.2"/>
+    <compilation debug="false" targetFramework="4.6.2"/>
     <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
         <add namespace="System.Web.Helpers"/>

--- a/test/NuGet.Licenses.Tests/GlobalSuppressions.cs
+++ b/test/NuGet.Licenses.Tests/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+[module: SuppressMessage("Microsoft.Security.Web.Configuration", "CA3103:EnableFormsRequireSSL", Justification = "This is a test project.")]

--- a/test/NuGet.Licenses.Tests/NuGet.Licenses.Tests.csproj
+++ b/test/NuGet.Licenses.Tests/NuGet.Licenses.Tests.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="LicenseControllerFacts.cs" />
     <Compile Include="LicenseExpressionSegmentatorFacts.cs" />
     <Compile Include="LicenseFileServiceFacts.cs" />


### PR DESCRIPTION
- Enable MicroBuild on the licenses project.
- Fix some FXCop errors. The `master` branch is currently broken due to stricter SDL rules.
- Suppress others in the same way that [gallery does](https://github.com/NuGet/NuGetGallery/blob/master/src/NuGetGallery/GlobalSuppressions.cs).
  - This is necessary because FXCop incorrectly tests the Web.Release.config and Web.Debug.config as independent configs.