### PR TITLE
Shorter maxRequestLength

### DIFF
--- a/src/NuGet.Licenses/Web.config
+++ b/src/NuGet.Licenses/Web.config
@@ -75,7 +75,7 @@
         <add namespace="System.Web.WebPages"/>
       </namespaces>
     </pages>
-    <httpRuntime targetFramework="4.6.2" maxUrlLength="1600" maxQueryStringLength="1600" maxRequestLength="256000" requestPathInvalidCharacters="&lt;,&gt;,*,:,\,?" relaxedUrlToFileSystemMapping="true" enableVersionHeader="false"/>
+    <httpRuntime targetFramework="4.6.2" maxUrlLength="1600" maxQueryStringLength="1600" maxRequestLength="4096" requestPathInvalidCharacters="&lt;,&gt;,*,:,\,?" relaxedUrlToFileSystemMapping="true" enableVersionHeader="false"/>
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web"/>
     </httpModules>


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/2318

The original value was taken from the Gallery's web.config and we obviously don't need it that large for licenses. 4096 is in KB, which is still plenty for the service.