### PR TITLE
Update System.Net.Http Dependency

### DIFF
--- a/src/NuGet.Licenses/NuGet.Licenses.csproj
+++ b/src/NuGet.Licenses/NuGet.Licenses.csproj
@@ -352,6 +352,9 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource">
       <Version>4.5.1</Version>
     </PackageReference>
+    <PackageReference Include="System.Net.Http">
+      <Version>4.3.4</Version>
+    </PackageReference>
     <PackageReference Include="WebGrease">
       <Version>1.6.0</Version>
     </PackageReference>


### PR DESCRIPTION
Pull new System.Net.Http 4.3.0 -> 4.3.4.

Instead of updating Serilog and Microsoft.Extensions.Logging, we will just pull up system.Net.Http dependency here.