### PR TITLE
Change nuget-build feed to new AzDO URL

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,7 +10,7 @@
   <packageSources>
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="nugetbuild" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />


### PR DESCRIPTION
For: NuGet/Engineering#2909
Redo of https://github.com/NuGet/NuGet.Licenses/pull/32 from an in-repo branch for CI