### PR TITLE
Adding AI trace listener

### DIFF
--- a/src/NuGet.Licenses/NuGet.Licenses.csproj
+++ b/src/NuGet.Licenses/NuGet.Licenses.csproj
@@ -115,8 +115,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.ApplicationInsights.TraceListener">
+      <Version>2.12.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.Web">
-      <Version>2.12.0</Version>
+      <Version>2.12.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.6</Version>

--- a/src/NuGet.Licenses/Web.config
+++ b/src/NuGet.Licenses/Web.config
@@ -244,7 +244,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.12.0.21496" newVersion="2.12.0.21496"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.12.2.43657" newVersion="2.12.2.43657"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Addresses https://github.com/NuGet/Engineering/issues/3673

`Web.config` for the service was referencing the `Microsoft.ApplicationInsights.TraceListener` but the library was not in the project, causing IIS to throw exceptions regularly failing to find the type.

https://github.com/NuGet/NuGet.Licenses/blob/6e1071eefaa608e4023c8f24f8d08361432acd7a/src/NuGet.Licenses/Web.config#L207

Bringing the missing package into the project. Test deployment in dev shows that exceptions are not thrown anymore.