### PR TITLE
Explicitly disabling CPM to unblock release builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The repository that includes this one as a submodule for release builds had a central package management enabled recently using `Directory.Packages.props`, but this repo was not updated. As a result, release builds are broken. This change explicitly disables CPM to unblock builds.